### PR TITLE
Ensure JspOC credentials are available at startup

### DIFF
--- a/edu.gemini.lch.configuration/pom.xml
+++ b/edu.gemini.lch.configuration/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <artifactId>lchUmbrella</artifactId>
         <groupId>edu.gemini.lch</groupId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <name>LCH Configuration</name>
     <artifactId>configuration</artifactId>
-    <version>3.4.0</version>
+    <version>3.5.0</version>
     <packaging>jar</packaging>
 
     <dependencies>
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>edu.gemini.lch</groupId>
             <artifactId>model</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
         </dependency>
 
         <!-- check if there is a javax package (not eclipse) -->

--- a/edu.gemini.lch.model/pom.xml
+++ b/edu.gemini.lch.model/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <artifactId>lchUmbrella</artifactId>
         <groupId>edu.gemini.lch</groupId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <name>LTTS Internal Data Model</name>
     <artifactId>model</artifactId>
-    <version>3.4.0</version>
+    <version>3.5.0</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/edu.gemini.lch.persistence/pom.xml
+++ b/edu.gemini.lch.persistence/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>lchUmbrella</artifactId>
         <groupId>edu.gemini.lch</groupId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <name>LCH Persistence Module</name>
     <artifactId>persistence</artifactId>
-    <version>3.4.0</version>
+    <version>3.5.0</version>
     <packaging>jar</packaging>
 
 
@@ -37,12 +37,12 @@
         <dependency>
             <groupId>edu.gemini.lch</groupId>
             <artifactId>model</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.lch</groupId>
             <artifactId>configuration</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
         </dependency>
 
         <!-- EXTERNAL DEPENDENCIES (3rd party libraries) -->
@@ -117,7 +117,7 @@
         <dependency>
             <groupId>edu.gemini.odb</groupId>
             <artifactId>browser-sim</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
         </dependency>
 
         <!-- external test only dependencies -->

--- a/edu.gemini.lch.services.model/pom.xml
+++ b/edu.gemini.lch.services.model/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>lchUmbrella</artifactId>
         <groupId>edu.gemini.lch</groupId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <name>LTTS Services Data Model</name>
     <artifactId>services-model</artifactId>
-    <version>3.4.0</version>
+    <version>3.5.0</version>
 
     <!-- make this an OSGi compliant bundle to be ready for re-use in QPT and CSS -->
     <packaging>bundle</packaging>

--- a/edu.gemini.lch.services/pom.xml
+++ b/edu.gemini.lch.services/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <artifactId>lchUmbrella</artifactId>
         <groupId>edu.gemini.lch</groupId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <name>LCH Services Module</name>
     <artifactId>services</artifactId>
-    <version>3.4.0</version>
+    <version>3.5.0</version>
     <packaging>jar</packaging>
 
     <!-- Build a test jar so that simulator classes can be used in web app for testing -->
@@ -43,22 +43,22 @@
         <dependency>
             <groupId>edu.gemini.odb</groupId>
             <artifactId>browser-client</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.odb</groupId>
             <artifactId>browser-api</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.lch</groupId>
             <artifactId>services-model</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.odb</groupId>
             <artifactId>browser-sim</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -185,12 +185,12 @@
         <dependency>
             <groupId>edu.gemini.lch</groupId>
             <artifactId>persistence</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.lch</groupId>
             <artifactId>pam-parser</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
         </dependency>
 
         <!-- internal test only -->
@@ -198,7 +198,7 @@
         <dependency>
             <groupId>edu.gemini.lch</groupId>
             <artifactId>persistence</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/edu.gemini.lch.services/src/main/java/edu/gemini/lch/services/impl/LoggingServiceImpl.java
+++ b/edu.gemini.lch.services/src/main/java/edu/gemini/lch/services/impl/LoggingServiceImpl.java
@@ -53,6 +53,7 @@ public class LoggingServiceImpl implements LoggingService {
         LOGGER.info("Environment            = " + siteService.getEnvironment());
         LOGGER.info("Version                = " + siteService.getVersion());
         LOGGER.info("Log configuration file = " + logConfigurationFile);
+        LOGGER.info("Start JspOC Service    = GN: " + JSpOCCredentials$.MODULE$.gnUserName() + " GS: " + JSpOCCredentials$.MODULE$.gsUserName());
         LOGGER.info("=================================================================================");
 
     }

--- a/edu.gemini.lch.services/src/main/scala/edu/gemini/lch/services/impl/JSpOCCredentials.scala
+++ b/edu.gemini.lch.services/src/main/scala/edu/gemini/lch/services/impl/JSpOCCredentials.scala
@@ -7,7 +7,11 @@ import scala.collection.immutable.HashMap
 
 object JSpOCCredentials {
   def unsafeGetEnv(key: String): String =
-    Option(System.getenv(key)).getOrElse(sys.error(s"Missing environment variable $key"))
+    Option(System.getenv(key)).getOrElse {
+      System.err.println("Missing environment variables")
+      // Absolutely kill the container
+      sys.exit(-1)
+    }
   val gsUserName = unsafeGetEnv("GS_USERNAME")
   val gsPassword = unsafeGetEnv("GS_PASSWORD")
   val gnUserName = unsafeGetEnv("GN_USERNAME")

--- a/edu.gemini.odb.browser.client/pom.xml
+++ b/edu.gemini.odb.browser.client/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <artifactId>lchUmbrella</artifactId>
         <groupId>edu.gemini.lch</groupId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <name>Gemini ODB Browser (Simulator)</name>
     <groupId>edu.gemini.odb</groupId>
     <artifactId>browser-client</artifactId>
-    <version>3.4.0</version>
+    <version>3.5.0</version>
     <packaging>jar</packaging>
 
     <dependencies>
@@ -20,12 +20,12 @@
         <dependency>
             <groupId>edu.gemini.lch</groupId>
             <artifactId>model</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.odb</groupId>
             <artifactId>browser-api</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
         </dependency>
 
         <!-- jersey client -->

--- a/edu.gemini.odb.browser.sim/pom.xml
+++ b/edu.gemini.odb.browser.sim/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <artifactId>lchUmbrella</artifactId>
         <groupId>edu.gemini.lch</groupId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <name>Gemini ODB Browser (Simulator)</name>
     <groupId>edu.gemini.odb</groupId>
     <artifactId>browser-sim</artifactId>
-    <version>3.4.0</version>
+    <version>3.5.0</version>
     <packaging>jar</packaging>
 
     <dependencies>
@@ -20,12 +20,12 @@
         <dependency>
             <groupId>edu.gemini.lch</groupId>
             <artifactId>model</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.odb</groupId>
             <artifactId>browser-api</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
         </dependency>
 
         <!-- JSKY -->

--- a/edu.gemini.odb.browser/pom.xml
+++ b/edu.gemini.odb.browser/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <artifactId>lchUmbrella</artifactId>
         <groupId>edu.gemini.lch</groupId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <name>Gemini ODB Browser (API)</name>
     <groupId>edu.gemini.odb</groupId>
     <artifactId>browser-api</artifactId>
-    <version>3.4.0</version>
+    <version>3.5.0</version>
     <!-- make this an OSGi bundle -->
     <packaging>bundle</packaging>
 

--- a/pam-parser/pom.xml
+++ b/pam-parser/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>lchUmbrella</artifactId>
         <groupId>edu.gemini.lch</groupId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -39,12 +39,12 @@
         <dependency>
             <groupId>edu.gemini.lch</groupId>
             <artifactId>model</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.lch</groupId>
             <artifactId>persistence</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>edu.gemini.lch</groupId>
     <artifactId>lchUmbrella</artifactId>
     <packaging>pom</packaging>
-    <version>3.4.0</version>
+    <version>3.5.0</version>
     <name>Laser Clearing House Umbrella Module</name>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,14 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <version>2.19.1</version>
+            <configuration>
+                <environmentVariables>
+                    <GS_USERNAME>gsuser</GS_USERNAME>
+                    <GS_PASSWORD>gspass</GS_PASSWORD>
+                    <GN_USERNAME>gnuser</GN_USERNAME>
+                    <GN_PASSWORD>gnpass</GN_PASSWORD>
+                </environmentVariables>
+            </configuration>
           </plugin>
 
             <!-- == OSGi BUNDLE MANAGEMENT == -->

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <artifactId>lchUmbrella</artifactId>
         <groupId>edu.gemini.lch</groupId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <name>LCH Web Module</name>
     <artifactId>web</artifactId>
-    <version>3.4.0</version>
+    <version>3.5.0</version>
     <packaging>war</packaging>
 
     <properties>
@@ -210,20 +210,20 @@
         <dependency>
             <groupId>edu.gemini.lch</groupId>
             <artifactId>services</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
         </dependency>
         <!-- reuse the test code of the services module (simulators) -->
         <dependency>
             <groupId>edu.gemini.lch</groupId>
             <artifactId>persistence</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>edu.gemini.lch</groupId>
             <artifactId>services</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Space Command credentials need to be provided via env variables and we wanted to kill LTTS if that wasn't the case

Turns out spring will catch the error and keep LTTS running anyway.
On top of that the variables weren't verified at startup

This PR fixes both cases.