### PR TITLE
REL-4166: Changed LTTS font sizes and box sizes to make status panel text fit.

### DIFF
--- a/web/src/main/java/edu/gemini/lch/web/app/windows/alarm/StatusPanel.java
+++ b/web/src/main/java/edu/gemini/lch/web/app/windows/alarm/StatusPanel.java
@@ -237,7 +237,7 @@ abstract class StatusPanel extends Panel {
                     // get first collision (sorted by time) and check if we need to react
                     // we need to react if a) laser is on sky and b) other telescope has priority
                     LtcsService.Collision c = collisions.get(0);
-                    Boolean needToReact = snapshot.getEpicsSnapshot().isOnSky() && !c.geminiHasPriority();
+                    boolean needToReact = snapshot.getEpicsSnapshot().isOnSky() && !c.geminiHasPriority();
 
                     if (!c.getStart().isAfter(epicsTime) && c.getEnd().isAfter(epicsTime)) {
                         // inside collision! calculate remaining time as time from now until end of collision

--- a/web/src/main/webapp/VAADIN/themes/lch/styles.css
+++ b/web/src/main/webapp/VAADIN/themes/lch/styles.css
@@ -49,8 +49,8 @@
 }
 
 .v-label-bigfont {
-    line-height: 80px;
-    font-size: 25pt;
+    line-height: 60px;
+    font-size: 18px;
     text-align: center;
 }
 


### PR DESCRIPTION
We have long had a UI issue in the LTTS where the font size in the status panels has been too big, sometimes cutting off important parts of the data. Here is a normal status which fits regularly but is bordering on not fitting for the Beam Collision status:
![ltts_gem](https://user-images.githubusercontent.com/8795653/184228194-ea1edd11-821c-4a6b-975d-c7534e5a741e.png)

Here is an example where the text does not fit and information is cut off:
![subarultcs](https://user-images.githubusercontent.com/8795653/184228262-101933b3-11ad-45c3-9425-1d3bbf5af2fc.png)

I have modified the CSS in order to shrink the text size down, and then tested with the largest possible value (I believe) to make sure that the status text does indeed fit. Here is the result of the test:
<img width="1583" alt="Screen Shot 2022-08-11 at 9 59 23 AM" src="https://user-images.githubusercontent.com/8795653/184228876-5d5737b4-4156-4594-aa14-8a1865e5a18d.png">

As is visible, the Beam Collision status now can list Subaru with the maximum digit width.

This addresses the long-standing fault:
[https://osc.hi.gemini.edu/browse/FR-72358](https://osc.hi.gemini.edu/browse/FR-71795)